### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ brew update
 If `brew` indicates there is a new version of `znotch`, then run:
 
 ``` sh
-brew cask upgrade znotch
-brew cask upgrade notunez
+brew upgrade --cask znotch
+brew upgrade --cask notunez
 ```
 


### PR DESCRIPTION
Fixes the following error

```sh
$ brew cask upgrade znotch
Error: `brew cask` is no longer a `brew` command. Use `brew <command> --cask` instead.
```